### PR TITLE
Fix to close appropriate tab

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -1,5 +1,6 @@
 var buttons = require('sdk/ui/button/action');
 var tabs = require("sdk/tabs");
+var { setTimeout } = require("sdk/timers");
 
 var button = buttons.ActionButton({
   id: "mozilla-link",
@@ -16,6 +17,14 @@ function handleClick(state) {
   var name = "Read - " + tabs.activeTab.title;
   var selection = require("sdk/selection");
   var note = tabs.activeTab.url + (selection.text != undefined ?  "\n" + selection.text : "");
-  tabs.open('omnifocus:///add?name=' + encodeURIComponent(name) + '&note=' + encodeURIComponent(note));
-  tabs.activeTab.close();
+  var currentTab = tabs.activeTab;
+  tabs.open({
+    url: 'omnifocus:///add?name=' + encodeURIComponent(name) + '&note=' + encodeURIComponent(note),
+    onOpen: function onOpen(tab) {
+      setTimeout(function() {
+        tab.close();
+        currentTab.activate();
+      });
+    }
+  });
 }

--- a/package.json
+++ b/package.json
@@ -1,9 +1,9 @@
 {
   "name": "addtoomnifocus",
   "title": "AddToOmnifocus",
-  "id": "jid1-A8HjG5DBf1hjNw",
   "description": "a basic add-on",
   "author": "",
+  "main": "lib/main.js",
   "license": "MPL 2.0",
-  "version": "0.1"
+  "version": "0.1.1"
 }


### PR DESCRIPTION
With latest stable release of Firefox, this addon doesn't close opening omnifocus tab, instead viewing tab when clicking the button.

917fe91 is the fix.

And c2325a2 is needed just to work with latest jpm, this is not intended to the part of fix but needed.
