### PR TITLE
Do not close current tab

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -17,5 +17,4 @@ function handleClick(state) {
   var selection = require("sdk/selection");
   var note = tabs.activeTab.url + (selection.text != undefined ?  "\n" + selection.text : "");
   tabs.open('omnifocus:///add?name=' + encodeURIComponent(name) + '&note=' + encodeURIComponent(note));
-  tabs.activeTab.close();
 }


### PR DESCRIPTION
I found it very annoying the the active tab is always closed after adding it to OmniFocus. There is also a review for this AddOn mentioning the same issue.
If I had more knowledge in Firefox AddOn I would add some settings to the AddOn.
- Close current tab: yes/no
- Configure tab title suffix/affix
- Shortcut